### PR TITLE
RCE Fixed in serializer.py

### DIFF
--- a/core/src/autogluon/core/utils/serialization.py
+++ b/core/src/autogluon/core/utils/serialization.py
@@ -3,6 +3,7 @@ import logging
 import difflib
 import inspect
 import os
+import pickle
 import io
 import struct
 import sys

--- a/core/src/autogluon/core/utils/serialization.py
+++ b/core/src/autogluon/core/utils/serialization.py
@@ -11,6 +11,28 @@ import zipfile
 import tempfile
 import warnings
 from contextlib import closing, contextmanager
+import builtins
+safe_builtins = {
+    'range',
+    'complex',
+    'set',
+    'frozenset',
+    'slice',
+}
+
+class RestrictedUnpickler(pickle.Unpickler):
+
+    def find_class(self, module, name):
+        """Only allow safe classes from builtins"""
+        if module == "builtins" and name in safe_builtins:
+            return getattr(builtins, name)
+        """Forbid everything else"""
+        raise pickle.UnpicklingError("global '%s.%s' is forbidden" %
+                                     (module, name))
+
+def restricted_loads(s):
+    """Helper function analogous to pickle.loads()"""
+    return RestrictedUnpickler(io.BytesIO(s)).load()
 
 if sys.version_info[0] == 2:
     import cPickle as pickle
@@ -72,9 +94,11 @@ def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
             (sys.version_info[0] == 2 and isinstance(f, unicode)):
         new_fd = True
         f = open(f, 'rb')
+        restricted_loads(f.read())
     elif (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
         new_fd = True
         f = f.open('rb')
+        restricted_loads(f.read())
     try:
         return _load(f, map_location, pickle_module, **pickle_load_args)
     finally:


### PR DESCRIPTION
### 📊 Metadata *

AutoGluon automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications. With just a few lines of code, you can train and deploy high-accuracy machine learning and deep learning models on text, image, and tabular data. This package was vulnerable to Arbitrary Code Execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-autogluon

### ⚙️ Description *

load() function is used to load predictor files by unpickling them. It should only unpickle trusted files generated with save() function.

### 💻 Technical Description *

Fixed by avoiding unsafe loader.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import pickle
import os
import autogluon

class EvilPickle(object):
    def __reduce__(self):
        return (os.system, ('calc.exe', ))

payload = pickle.dumps(EvilPickle())

with open('payload', 'wb') as f:
    f.write(payload)

autogluon.load('payload')
```

Execute the following commands in another terminal:

```
python3 exploit.py
```

### 🔥 Proof of Fix (PoF) *

After fix it will not popup a calc.

### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected

### 🔗 Relates to...

https://github.com/418sec/autogluon/blob/6c1ef8a7596ab2c12f46c3f62867964ec9971b03/core/src/autogluon/core/utils/serialization.py